### PR TITLE
Fix Goreleaser config file after v2 upgrade

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
+version: 2
 before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing


### PR DESCRIPTION
```
GoReleaser latest installed successfully
v2.23.0 tag found for commit '8521a2b'
/opt/hostedtoolcache/goreleaser-action/2.0.1/x64/goreleaser release --clean
  • starting release...
  • only configurations files on version: 2 are supported, yours is version: 0, please update your configuration
  ⨯ release failed after 0s                  error=only configurations files on version: 2 are supported, yours is version: 0, please update your configuration
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.0.1/x64/goreleaser' failed with exit code 1
```
see https://goreleaser.com/blog/goreleaser-v2/#upgrading 