### PR TITLE
fix(PSRE-2088): error when setting owner on publication with "-"s

### DIFF
--- a/postgresql/resource_postgresql_publication.go
+++ b/postgresql/resource_postgresql_publication.go
@@ -158,7 +158,7 @@ func setPubOwner(txn *sql.Tx, d *schema.ResourceData) error {
 	n := nraw.(string)
 	pubName := d.Get(pubNameAttr).(string)
 
-	sql := fmt.Sprintf("ALTER PUBLICATION %s OWNER TO %s", pubName, n)
+	sql := fmt.Sprintf("ALTER PUBLICATION %s OWNER TO \"%s\"", pubName, n)
 	if _, err := txn.Exec(sql); err != nil {
 		return fmt.Errorf("Error updating publication owner: %w", err)
 	}


### PR DESCRIPTION
It's impossible to set the owner of the publication when this one contains dashes in the name